### PR TITLE
Use AM CSV validation endpoint

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 amclient==1.2.0
 asterism==0.7.4
 bagit==1.8.1
-csvvalidator==1.2
 Django==3.2.10
 djangorestframework==3.12.4
 health-check==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,6 @@ clinner==1.12.3
     # via health-check
 colorlog==3.2.0
     # via clinner
-csvvalidator==1.2
-    # via -r requirements.in
 django==3.2.10
     # via
     #   -r requirements.in

--- a/sip_assembly/routines.py
+++ b/sip_assembly/routines.py
@@ -115,7 +115,7 @@ class RestructurePackageRoutine(BaseRoutine, ArchivematicaClientMixin):
         helpers.move_objects_dir(sip.bag_path)
         helpers.create_structure(sip.bag_path)
         if sip.data['rights_statements']:
-            CsvCreator(settings.ARCHIVEMATICA_VERSION).create_rights_csv(sip.bag_path, sip.data.get('rights_statements'))
+            CsvCreator(settings.ARCHIVEMATICA_VERSION, client).create_rights_csv(sip.bag_path, sip.data.get('rights_statements'))
         helpers.add_processing_config(
             sip.bag_path, self.get_processing_config(client))
         bagit_helpers.update_bag_info(


### PR DESCRIPTION
Removes custom local CSV validation in favor of Archivematica's CSV validation endpoint. Fixes #167 

Also added a test for invalid CSVs. This gets our test coverage up to 97% overall 🎉 